### PR TITLE
Allow configurable email resource class

### DIFF
--- a/config/filament-email.php
+++ b/config/filament-email.php
@@ -4,6 +4,7 @@
 return [
 
     'resource' => [
+        'class' => null,
         'group' => null,
         'sort' => null,
         'default_sort_column' => 'created_at',

--- a/config/filament-email.php
+++ b/config/filament-email.php
@@ -1,10 +1,12 @@
 <?php
 
 // config for RickDBCN/FilamentEmail
+use RickDBCN\FilamentEmail\Filament\Resources\EmailResource;
+
 return [
 
     'resource' => [
-        'class' => null,
+        'class' => EmailResource::class,
         'group' => null,
         'sort' => null,
         'default_sort_column' => 'created_at',

--- a/src/FilamentEmail.php
+++ b/src/FilamentEmail.php
@@ -16,7 +16,7 @@ class FilamentEmail implements Plugin
     public function register(Panel $panel): void
     {
         $panel->resources([
-            EmailResource::class,
+            config('filament-email.resource.class', EmailResource::class)
         ]);
     }
 


### PR DESCRIPTION
This PR simply adds the option to use a different Email Resource class, by adding an entry in the config.

Solves #19 