### PR TITLE
fix(): sort from config is ignored

### DIFF
--- a/src/Filament/Resources/EmailResource.php
+++ b/src/Filament/Resources/EmailResource.php
@@ -41,7 +41,7 @@ class EmailResource extends Resource
 
     public static function getNavigationSort(): ?int
     {
-        return Config::set('filament-email.resource.sort') ?? parent::getNavigationSort();
+        return Config::get('filament-email.resource.sort') ?? parent::getNavigationSort();
     }
 
     public static function form(Form $form): Form


### PR DESCRIPTION
Hi!

There is a small typo in the getNavigationSort function.
It uses set instead of get, so even if we set a sort in the config file, it is currently ignored