### PR TITLE
Make Email model changeable from config

### DIFF
--- a/config/filament-email.php
+++ b/config/filament-email.php
@@ -2,11 +2,13 @@
 
 // config for RickDBCN/FilamentEmail
 use RickDBCN\FilamentEmail\Filament\Resources\EmailResource;
+use RickDBCN\FilamentEmail\Models\Email;
 
 return [
 
     'resource' => [
         'class' => EmailResource::class,
+        'model' => Email::class,
         'group' => null,
         'sort' => null,
         'default_sort_column' => 'created_at',

--- a/database/factories/EmailFactory.php
+++ b/database/factories/EmailFactory.php
@@ -3,13 +3,17 @@
 namespace RickDBCN\FilamentEmail\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Config;
 use RickDBCN\FilamentEmail\Models\Email;
 
 class EmailFactory extends Factory
 {
-    protected $model = Email::class;
+    public function modelName(): string
+    {
+        return Config::get('filament-email.resource.model') ?? Email::class;
+    }
 
-    public function definition()
+    public function definition(): array
     {
         return [
             'from' => $this->faker->email(),

--- a/src/Filament/Resources/EmailResource.php
+++ b/src/Filament/Resources/EmailResource.php
@@ -23,8 +23,6 @@ use RickDBCN\FilamentEmail\Models\Email;
 
 class EmailResource extends Resource
 {
-    protected static ?string $model = Email::class;
-
     protected static ?string $navigationIcon = 'heroicon-o-envelope';
 
     protected static ?string $slug = 'emails';
@@ -42,6 +40,11 @@ class EmailResource extends Resource
     public static function getNavigationSort(): ?int
     {
         return Config::get('filament-email.resource.sort') ?? parent::getNavigationSort();
+    }
+
+    public static function getModel(): string
+    {
+        return Config::get('filament-email.resource.model') ?? Email::class;
     }
 
     public static function form(Form $form): Form
@@ -99,7 +102,7 @@ class EmailResource extends Resource
                         fn ($action): array => [
                             $action->getModalCancelAction(),
                         ])
-                    ->fillForm(function (Email $record) {
+                    ->fillForm(function ($record) {
                         $body = $record->html_body;
 
                         return [
@@ -113,7 +116,7 @@ class EmailResource extends Resource
                 Action::make('resend')
                     ->label(__('Send again'))
                     ->icon('heroicon-o-envelope')
-                    ->action(function (Email $record) {
+                    ->action(function ($record) {
                         try {
                             Mail::to($record->to)
                                 ->cc($record->cc)

--- a/src/Listeners/FilamentEmailLogger.php
+++ b/src/Listeners/FilamentEmailLogger.php
@@ -2,6 +2,7 @@
 
 namespace RickDBCN\FilamentEmail\Listeners;
 
+use Illuminate\Support\Facades\Config;
 use RickDBCN\FilamentEmail\Models\Email;
 
 class FilamentEmailLogger
@@ -24,7 +25,9 @@ class FilamentEmailLogger
         $rawMessage = $event->sent->getSymfonySentMessage();
         $email = $event->message;
 
-        Email::create([
+        $model = Config::get('filament-email.resource.model') ?? Email::class;
+
+        $model::create([
             'from' => $this->recipientsToString($email->getFrom()),
             'to' => $this->recipientsToString($email->getTo()),
             'cc' => $this->recipientsToString($email->getCc()),

--- a/src/Mail/ResendMail.php
+++ b/src/Mail/ResendMail.php
@@ -7,15 +7,14 @@ use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
-use RickDBCN\FilamentEmail\Models\Email;
 
 class ResendMail extends Mailable
 {
     use Queueable, SerializesModels;
 
-    public Email $email;
+    public $email;
 
-    public function __construct(Email $email)
+    public function __construct($email)
     {
         $this->email = $email;
     }

--- a/tests/EmailModelTest.php
+++ b/tests/EmailModelTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Faker\Factory;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Mail;
 use RickDBCN\FilamentEmail\Filament\Resources\EmailResource\Pages\ListEmails;
 use RickDBCN\FilamentEmail\Models\Email;
@@ -9,6 +10,10 @@ use function Pest\Laravel\assertDatabaseCount;
 use function Pest\Laravel\assertModelExists;
 use function Pest\Livewire\livewire;
 use function PHPUnit\Framework\assertEquals;
+
+beforeEach(function () {
+    $this->model = Config::get('filament-email.resource.model') ?? Email::class;
+});
 
 it('can create an Email model', function () {
     $emailModel = Email::factory()->create();
@@ -26,17 +31,17 @@ it('can capture a sent email', function () {
 
     assertDatabaseCount('filament_email_log', 1);
 
-    assertEquals(Email::first()->to, $recipient);
+    assertEquals($this->model::first()->to, $recipient);
 });
 
 it('can render table page', function () {
-    Email::factory()->create();
+    $this->model::factory()->create();
     livewire(ListEmails::class)->assertSuccessful();
 });
 
 it('can resend email', function () {
-    $email = Email::factory()->create();
+    $email = $this->model::factory()->create();
     livewire(ListEmails::class)
         ->callTableAction('resend', $email);
-    assertDatabaseCount((new Email)->getTable(), 2);
+    assertDatabaseCount((new $this->model)->getTable(), 2);
 });


### PR DESCRIPTION
This pull request makes the Email model configurable via the `config/filament-email.php` config file.
This allows users to override the Email model used by the package.