### PR TITLE
Fix issue with event registration

### DIFF
--- a/src/Providers/EmailMessageServiceProvider.php
+++ b/src/Providers/EmailMessageServiceProvider.php
@@ -2,12 +2,12 @@
 
 namespace RickDBCN\FilamentEmail\Providers;
 
-use Illuminate\Events\EventServiceProvider;
 use Illuminate\Mail\Events\MessageSent;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\ServiceProvider;
 use RickDBCN\FilamentEmail\Listeners\FilamentEmailLogger;
 
-class EmailMessageServiceProvider extends EventServiceProvider
+class EmailMessageServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {


### PR DESCRIPTION
Resolves https://github.com/RickDBCN/filament-email/issues/37

Some notes:
1. It seems that the `EmailMessageServiceProvider` extending from Laravel's `EventServiceProvider` messes up event registration
2. I checked other packages that listen for the `MessageSent` event, and they only extend from `Illuminate\Support\ServiceProvider`
3. When I tried it, things started working again. The listeners in `EventServiceProvider@listen` get registered again, and the listener of the package gets registered automatically via autodiscovery again
4. There is no reason to extend from `EventServiceProvider` just to use `Event::listen`, since you could technically use `Event::listen` from any service provider, so extending from `ServiceProvider` should be alright and is probably more correct. It seems extending from `Illuminate\Events\EventServiceProvider` is what broke listener registration on our end
