### PR TITLE
Allow disabling of scheduled prune

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ return [
     'keep_email_for_days' => 60,
     'label' => null,
 
+    'prune_enabled' => true,
     'prune_crontab' => '0 0 * * *',
 
     'can_access' => [

--- a/config/filament-email.php
+++ b/config/filament-email.php
@@ -26,6 +26,7 @@ return [
     'keep_email_for_days' => 60,
     'label' => null,
 
+    'prune_enabled' => true,
     'prune_crontab' => '0 0 * * *',
 
     'can_access' => [

--- a/src/FilamentEmailServiceProvider.php
+++ b/src/FilamentEmailServiceProvider.php
@@ -35,6 +35,10 @@ class FilamentEmailServiceProvider extends PackageServiceProvider
 
     public function bootingPackage()
     {
+        if(! config('filament-email.prune_enabled')) {
+            return;
+        }
+
         $this->callAfterResolving(Schedule::class, function (Schedule $schedule) {
             $runCrontab = config('filament-email.prune_crontab', '0 0 * * *');
             $modelClass = config('filament-email.resource.model') ?? Email::class;


### PR DESCRIPTION
### Details
This allows us to disable the scheduled command `model:prune` introduced by this package. 

This is needed for cases where we want to add a `->doNotMonitor()` (from [spatie/laravel-schedule-monitor](https://github.com/spatie/laravel-schedule-monitor/blob/main/config/schedule-monitor.php)) to the scheduled command. With this, we will set the config to `'prune_enabled' => false` then add the scheduled command `model:prune` to our own Kernel.php with `->doNotMonitor()`.