### PR TITLE
Gives the option to always save 'null' to the 'team_id' column

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ return [
     //Use this option for customize tenant model class
     //'tenant_model' => \App\Models\Team::class,
 
+    'persist_team_id' => true,
+
 ];
 ```
 

--- a/config/filament-email.php
+++ b/config/filament-email.php
@@ -46,4 +46,6 @@ return [
     //Use this option for customize tenant model class
     //'tenant_model' => \App\Models\Team::class,
 
+    'persist_team_id' => true,
+
 ];

--- a/src/Listeners/FilamentEmailLogger.php
+++ b/src/Listeners/FilamentEmailLogger.php
@@ -31,7 +31,7 @@ class FilamentEmailLogger
         $storeAttachments = config('filament-email.store_attachments', true);
 
         $model = config('filament-email.resource.model') ?? Email::class;
-
+        
         $attachments = [];
         $savePath = 'filament-email-log'.DIRECTORY_SEPARATOR.date('YmdHis').'_'.Str::random(5).DIRECTORY_SEPARATOR;
 
@@ -57,7 +57,7 @@ class FilamentEmailLogger
             $savePathRaw = null;
         }
         $model::create([
-            'team_id' => Filament::getTenant()?->id ?? null,
+            'team_id' => $this->getTeamId(),
             'from' => $this->recipientsToString($email->getFrom()),
             'to' => $this->recipientsToString($email->getTo()),
             'cc' => $this->recipientsToString($email->getCc()),
@@ -80,5 +80,14 @@ class FilamentEmailLogger
                 return "{$email->getAddress()}".($email->getName() ? " <{$email->getName()}>" : '');
             }, $recipients)
         );
+    }
+
+    private function getTeamId(): ?int
+    {
+        if(config('filament-email.persist_team_id')){
+            return Filament::getTenant()?->id ?? null;
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
Gives the option in the configuration to always save the `team_id` as null in order for people to see all logged emails and not filter them by teams. (This works perfectly for admin)