### PR TITLE
Move scoping to filament resource and add config var.

### DIFF
--- a/config/filament-email.php
+++ b/config/filament-email.php
@@ -46,5 +46,6 @@ return [
 
     // Use this option for customize tenant model class
     // 'tenant_model' => \App\Models\Team::class,
+    'scope_to_tenant' => true
 
 ];

--- a/config/filament-email.php
+++ b/config/filament-email.php
@@ -44,7 +44,7 @@ return [
     'attachments_disk' => 'local',
     'store_attachments' => true,
 
-    // Use this option for customize tenant model class
+    // Custom tenancy options
     // 'tenant_model' => \App\Models\Team::class,
     // 'scope_to_tenant' => true
 

--- a/config/filament-email.php
+++ b/config/filament-email.php
@@ -46,6 +46,6 @@ return [
 
     // Use this option for customize tenant model class
     // 'tenant_model' => \App\Models\Team::class,
-    'scope_to_tenant' => true
+    // 'scope_to_tenant' => true
 
 ];

--- a/src/Filament/Resources/EmailResource.php
+++ b/src/Filament/Resources/EmailResource.php
@@ -34,6 +34,15 @@ use RickDBCN\FilamentEmail\Models\Email;
 class EmailResource extends Resource
 {
     protected static ?string $slug = 'emails';
+    protected static ?string $tenantOwnershipRelationshipName = 'team';
+
+    /**
+     * Determine whether the resource should be scoped to the current tenant.
+     */
+    public static function isScopedToTenant(): bool
+    {
+        return config('filament-email.scope_to_tenant', true);
+    }
 
     public static function getBreadcrumb(): string
     {

--- a/src/Models/Email.php
+++ b/src/Models/Email.php
@@ -50,19 +50,6 @@ class Email extends Model
         return $this->belongsTo(config('filament-email.tenant_model'), 'team_id', 'id');
     }
 
-    protected static function booted(): void
-    {
-        static::addGlobalScope('teams', function (Builder $query) {
-            if (! app()->runningInConsole()) {
-                if (auth()->check() && Filament::getTenant()) {
-                    $query->whereBelongsTo(auth()->user()?->teams);
-                } else {
-                    $query->whereTeamId(null);
-                }
-            }
-        });
-    }
-
     public static function boot()
     {
         parent::boot();


### PR DESCRIPTION
This should fix:
https://github.com/RickDBCN/filament-email/issues/106
https://github.com/RickDBCN/filament-email/issues/80

Scoping was previously applied to the Email eloquent model. Filament usually applies scoping to the resource.

I have removed model scoping, updated the filament resource and added a config var to toggle scoping on the resource as per user requirements.

I am using this fork on my own projects and it works fine but please double check that removing model scoping has no effect on other features or different tenancy uses.

Thanks!