### PR TITLE
Add support for Laravel 13 and PHP 8.5

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.3, 8.4]
-        laravel: [11.*, 12.*]
+        php: [8.3, 8.4, 8.5]
+        laravel: [11.*, 12.*, 13.*]
         stability: [prefer-stable]
         include:
           - laravel: 11.*
@@ -25,6 +25,13 @@ jobs:
             testbench: 10.*
             carbon: 3.*
             filament: 4.*
+          - laravel: 13.*
+            testbench: 11.*
+            carbon: 3.*
+            filament: 5.*
+        exclude:
+          - php: 8.3
+            laravel: 13.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Log all outgoing emails in your Laravel project within your Filament panel. You 
 | 1.x    | 3.x        | 10.x | 8.x |
 | 1.x    | 3.x        | 11.x \| 12.x | 8.2 \| 8.3 \| 8.4 |
 | 2.x    | 4.x \| 5.x | 11.x \| 12.x | 8.3 \| 8.4 |
+| 2.x    | 4.x \| 5.x | 13.x | 8.4 \| 8.5 |
 
 > [!CAUTION]
 > After update to v1.3.1 or 1.4.0 you need to re-publish and run migrations

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,15 @@
     "require": {
         "php": "^8.3",
         "filament/filament": "^4.0|^5.0",
-        "illuminate/contracts": "^11.0|^12.0",
-        "laravel/framework": "^11.0|^12.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
+        "laravel/framework": "^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.16.0",
         "malzariey/filament-daterangepicker-filter": "^4.0"
     },
     "require-dev": {
         "laravel/pint": "^1.25",
         "nunomaduro/collision": "^8.0",
-        "orchestra/testbench": "^10.0",
+        "orchestra/testbench": "^10.0|^11.0",
         "pestphp/pest": "^4.1",
         "pestphp/pest-plugin-arch": "^4.0",
         "pestphp/pest-plugin-laravel": "^4.0",

--- a/src/Models/Email.php
+++ b/src/Models/Email.php
@@ -48,11 +48,9 @@ class Email extends Model
         return $this->belongsTo(config('filament-email.tenant_model'), 'team_id', 'id');
     }
 
-    public static function boot()
+    protected static function booted(): void
     {
-        parent::boot();
-
-        self::deleting(function ($record) {
+        static::deleting(function ($record) {
             $folderPath = '';
             $storageDisk = config('filament-email.attachments_disk', 'local');
             if (! empty($record->attachments)) {


### PR DESCRIPTION
This adds support for Laravel 13 and PHP 8.5

## Changes

  - Add `^13.0` to `laravel/framework` and `illuminate/contracts` constraints
  - Add `^11.0` to `orchestra/testbench` dev dependency
  - Add PHP 8.5 and Laravel 13 to the CI test matrix (with PHP 8.3 excluded for Laravel 13, as it requires 8.4+)
  - Replace `boot()` with `booted()` in `Email` model — Laravel 13 throws a `LogicException` when registering observer events during `boot()` (see [upgrade guide](https://laravel.com/docs/13.x/upgrade)).
  - Update README version compatibility table

---

Thanks again, let me know if you'd like any adjustments made to this PR.